### PR TITLE
Big edits to Install, small edits to Indexing

### DIFF
--- a/content/docs/prologue/indexing.md
+++ b/content/docs/prologue/indexing.md
@@ -12,7 +12,7 @@ weight: 0400
 toc: true
 ---
 
-We assume that you've already completed the [Installation](/docs/prologue/installing/) task. Please do so now before proceeding.
+This article assumes that you've already [Installed TrueBlocks core](/docs/prologue/installing/). If you haven't, please do so before proceeding.
 
 ## Introduction
 
@@ -24,13 +24,16 @@ In this article, we explain how you can get a copy of the TrueBlock index of app
 
 If you have access to an Ethereum tracing node such as TurboGeth, you can build the TrueBlocks index yourself. For information on that, please see our [Blog](/docs/blog/).
 
-For this page, we will take advantage of the fact that TrueBlocks, LLC (the company) produces the index and publishes it to IPFS. We do this for our own reasons -- our software doesn't work without it. We purposefully publish the index data to IPFS so that once our users have it, we can not take it back. This makes it impossible for us to hold our users hostage.
+For this page, we take advantage of the fact that TrueBlocks, LLC (the company) produces the index and publishes it to IPFS. We do this for our own reasons─our software doesn't work without it.
+We purposefully publish the index data to IPFS so that once our users have it, we can not take it back. This makes it impossible for us to hold our users hostage.
 
-Each time we publish an index chunk (and it's associated bloom filter) to IPFS, we add a record to a *manifest*. The manifest lists all of the index chunks and bloom filters.
+Each time we publish an index chunk (and its associated bloom filter) to IPFS, we add a record to a *manifest*. The manifest lists all of the index chunks and bloom filters.
 
-For the same reason as above (so we can't take it back), we publish the manifest to IPFS. This gives us an IPFS hash to the manifest which gives us a list of all the IPFS hashes of the entire address index. In other words, we've published immutable, irrevocable access to the entire index for anyone who has the hash of the manifest to use -- not only now but into the far foggy future. The manifest will be there forever. It's immutable data and it's permissionlessly, globally available.
+So we can't take it back, we publish the manifest to IPFS. This IPFS hash to the manifest gives us a list of all the IPFS hashes of the entire address index.
+In other words, we've published immutable, irrevocable access to the entire index for anyone who has the hash of the manifest to use─not only now but into the far foggy future.
+The manifest will be there forever. It's immutable data and it's permissionlessly, globally available.
 
-We go one step further -- we publish the hash of the manifest to a smart contract called [The Unchained Index](http://unchainedindex.io).
+We go one step further─we publish the hash of the manifest to a smart contract called [The Unchained Index](http://unchainedindex.io).
 
 ## Getting the Latest Manifest
 
@@ -74,7 +77,7 @@ Where:
   -g  (--tags)          export the list of tags and subtags only
 ```
 
-You can type `chifra names` to see all the addresses we've accumulated over the years. (Yes -- we can use ENS to enhance this search and we plan to in the near future.)
+You can type `chifra names` to see all the addresses we've accumulated over the years. (Yes─we can use ENS to enhance this search and we plan to in the near future.)
 
 Type
 
@@ -94,7 +97,7 @@ Copy and paste this response. We will need it. The next thing we need is the ABI
 chifra abis 0xcfd7f3b24f3551741f922fd8c4381aa4e00fc8fd
 ```
 
-This will return the full ABI of the Unchained Index smart contract. You should be able to see a function called `manifestHash` with a four-byte signature of `0x337f3f32`.
+This returns the full ABI of the Unchained Index smart contract. You should be able to see a function called `manifestHash` with a four-byte signature of `0x337f3f32`.
 
 Now we're going to do something fun. Type this
 
@@ -127,6 +130,6 @@ curl -s "http://gateway.ipfs.io/ipfs/QmSJeyXsvNpyXprdfwL5JyiS39VLU7m1kQNun4uM5XQ
 
 ## Getting all the Blooms
 
-Additionally, we publish the IPFS hash of a manifest file -- which details all the hashes of all the chunks of the index along with all the bloom filters -- to a smart contract we call the *Unchained Index*.
+Additionally, we publish the IPFS hash of a manifest file to smart contract we call the *Unchained Index.* The mainfest file details all the hashes of all the chunks of the index along with all the bloom filters.
 
 [ UNDER CONSTRUCTION -- PLEASE RETURN LATER ]

--- a/content/docs/prologue/installing.md
+++ b/content/docs/prologue/installing.md
@@ -12,47 +12,48 @@ weight: 0200
 toc: true
 ---
 
-The following instructions help you compile the `core` tools from the TrueBlocks github repo.
-You may also be interested in the [TrueBlocks Explorer](https://github.com/TrueBlocks/trueblocks-explorer) or the [Docker Version](https://github.com/TrueBlocks/trueblocks-docker)
+To use the core tools of TrueBlocks, you need to go through a few installation steps.
 
-## Installing Dependencies
+0. Install dependencies
+1. Compile from the codebase
+2. Add `trueblock-core/bin` to your shell PATH.
+3. Update configs for your RPC endpoints and API keys
 
-## Prerequisites
+## Install
 
----
+The following instructions walk you through these steps with a bit more context.
+If you have any trouble, you might want to jump to the corresponding section in [troubleshooting](#how-do-i-check-my-go-version).
 
-**For Linux**:
+### 0. Install dependencies
 
-```shell
-sudo apt install build-essential git cmake python python-dev libcurl3-dev clang-format jq
-```
+**Install golang** with [these instructions from the GoLang website](https://golang.org/doc/install).
+TrueBlocks requires Go version 1.12.x or later.
 
-**For Mac**:
+**Install the other prereqs** with your cli:
 
-```shell
-brew install cmake
-brew install git
-brew install clang-format
-brew install jq
-```
+* For Linux:
 
-We recommend that you run MacOS Big Sur or later for best results.
+  ```shell
+  sudo apt install build-essential git cmake python python-dev libcurl3-dev clang-format jq
+  ```
 
-**For Windows**:
+* For Mac:
 
-TrueBlocks does not currently support Windows builds.
+  _For best results, we recommend running MacOS Big Sur or later._  
 
-**Golang**:
+  ```shell
+  brew install cmake
+  brew install git
+  brew install clang-format
+  brew install jq
+  ```
 
-For all operating systems, you must also install GoLang. Please follow [these instructions](https://golang.org/doc/install) to install `golang` on your system. When you're done, run this command
+* For Windows:
 
-```[shell]
-go version
-```
+  TrueBlocks does not currently support Windows builds.
+  Some users have had luck using WSL. For now─you’re on your own!
 
-Make sure you're running at least Go version 1.12.x or later.
-
-## Compiling TrueBlocks
+### 1. Compile
 
 ```shell
 git clone -b develop git@github.com:TrueBlocks/trueblocks-core.git
@@ -62,38 +63,111 @@ cmake ../src
 make
 ```
 
-(You may use `make -j <ncores>` to parallelize the build. Replace `<ncores>` with the number of cores on your machine.)
+_(You may use `make -j <ncores>` to parallelize the build. Replace `<ncores>` with the number of cores on your machine.)_
 
-The compilation creates a number of executables in `../bin`.
+#### Test build
 
-Run this command
+To test your install, run this command
 
 ```shell
 ../bin/chifra --version
 ```
 
-You should get a version string similar to the below
+You should get a version string similar to this:
 
 ```shell
 trueBlocks GHC-TrueBlocks//0.9.0-alpha-409aa9388-20210503
 ```
 
-If not, review the above commands and make sure you didn't miss something. [Create an issue](https://github.com/TrueBlocks/trueblocks-core/issues) if you continue to have trouble.
+If you didn't, see the [corresponding section in troubleshooting](#no-version-outputted).
 
-## Adding ./bin to your $PATH
+### 2. Add `trueblocks-core/bin` to PATH
 
 `chifra` only works if its underlying tools are found in your $PATH.
+For guidance, see the [corresponding section in troubleshooting](#adding-bin-to-path).
 
-Add the full path to `./trueblocks-core/bin` to your shell's default environment. To find the full path, do this
+### 3. Update the configs for your RPC and API keys
 
-```shell
-cd ../bin && pwd && cd -
+To add your RPC endpoints and API keys, add these lines to `trueBlocks.toml` under `[settings]`:
+
+```toml
+[settings]
+rpcProvider = "<url-to-rpc-endpoint>"
+etherscan_key = "<key>"
 ```
 
-Add the result of that command to your shell's $PATH. If you don't know what we mean, a Google search may be in order...
+For help, see [Where is my config file?](#where-is-my-config-file).
+
+By default, TrueBlocks checks for an RPC on `http://localhost:8545/`.
+If you are running a local node on a different port, simply change the port.
+If you are using an external RPC, you to need add its endpoint.
+Similarly, [some tools have an `--articulate` option](https://docs.trueblocks.io/docs/chifra/chaindata/),
+which requires an EtherScan API key.
+
+The location of your config file depends on your OS and your environment
+settings. Again, for more details, see the [corresponding section in troubleshooting](#Where-is-my-config).
+
+#### Test Install
+
+Run a chifra command! This one returns data about block 100.
+
+```shell
+chifra blocks 100
+```
+
+## Troubleshooting
+
+Here are some problems users have run into at each step. If you're still having trouble, [create an issue](https://github.com/TrueBlocks/trueblocks-core/issues).
+
+### Dependencies
+
+#### How do I check my Go version
+
+```shell
+go version
+```
+
+TrueBlocks needs version 1.12.x or later.
+
+### Compiling
+
+#### No version outputted
+
+From the top of the trueblocks-core repo, check your version with `bin/chifra --version`.
+If nothing ouputs, then the build has failed.
+Please make sure you’ve reviewed the commands in steps 0 and 1.
+If you continue to have trouble, create an issue.
+
+### Adding bin to path
+
+Add the full path to `trueblocks-core/bin` to your shell’s default environment.
+To find the full path, run this from the top of the `trueblocks-core` directory.
+
+```shell
+cd bin && pwd && cd -
+```
+
+Add the result of that command to your shell’s `$PATH`.
+How you do that depends on your system.
+If you are confused, a Google search may be in order…
+
+### Adding configs
+
+#### Where is my config file
+
+TrueBlocks follows the [XDG base directory](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html) spec.
+
+The location of `trueBlocks.toml` (and all other configs) depends on the value of your `$XDG_DATA_HOME` variable.
+By default, this is:
+
+* On linux at `~/.local/share/trueblocks`
+* On mac at `~/Library/Application/Support/TrueBlocks`
+
+If the config is not there, someone has set a value your default data directory!
+Run `echo $XDG_DATA_HOME`, and hopefully you'll know what to do :-).
 
 ## Conclusion
 
-On this page, we've shown you how to install TrueBlocks and have gotten your started running `chifra`. All of the chifra commands should now work. The next section further introduces you to `chifra`.
-
-Please see the [Introducing Chifra](/docs/prologue/introducing-chifra/) if you wish to actually get productive.
+On this page, we've shown you how to install TrueBlocks and have gotten you started running `chifra`.
+`chifra` is the overarching command for all TrueBlocks tools.
+The next section further introduces you to `chifra`.


### PR DESCRIPTION
The index edits are uncontroversial. 

The install edits are more substantive. I've separated the install from the troubleshooting aspects. I still think install is too long, but this is better. And at least this way we have some separation between Imperative-voice instructions and declarative-voice troubleshooting advice.