### PR TITLE
Fix typos

### DIFF
--- a/APIHELP
+++ b/APIHELP
@@ -304,7 +304,7 @@
                   {
                     name: 'blooms',
                     in: 'query',
-                    description: 'process query by first using bloom filter and, if hit, downloading index chunk from remote',
+                    description: 'process query by first using Bloom filter and, if hit, downloading index chunk from remote',
                     required: false,
                     style: 'form',
                     explode: true,

--- a/content/blog/explainers/long-winded-explanation.md
+++ b/content/blog/explainers/long-winded-explanation.md
@@ -175,15 +175,15 @@ time-ordered log of indexes of a time-ordered log*.
 
 ### Bloom Filters
 
-Before I move on, a quick note about bloom filters. [[Bloom
+Before I move on, a quick note about Bloom filters. [[Bloom
 filters]{.ul}](https://en.wikipedia.org/wiki/Bloom_filter) are an
 amazing data structure that do an amazing thing. They represent, in a
 very compact form, set membership in a data set such as an index.
 
-After creating each **index chunk**, we also create a bloom filter in
+After creating each **index chunk**, we also create a Bloom filter in
 front of that chunk that represents the set membership. In addition to
 publishing the **index chunk** itself to IPFS, we publish the chunk's
-bloom filter. The bloom filter will be seen to be super useful in
+Bloom filter. The Bloom filter will be seen to be super useful in
 creating the system that we want to create \-- a system that allows us
 to distribute the index to our end users very efficiently.
 
@@ -193,7 +193,7 @@ The scraper, in addition to querying each block and extracting
 appearances of addresses continually inserts them into the currently
 active chunk. Each time it inserts new records, it decides if the index
 has grown "large enough". If the index is large enough, the scraper
-creates a new chunk, creates the corresponding bloom filter, and
+creates a new chunk, creates the corresponding Bloom filter, and
 publishes both of these files to IPFS, storing away the hash and then it
 begins accumulating the next chunk.
 
@@ -211,28 +211,28 @@ appearing in any given chunk. We will write about this fascinating issue
 later.
 
 Given a series of chunked indexes, each chunk of which has an associated
-bloom filter, we are now ready to get what we want\--a list of every
+Bloom filter, we are now ready to get what we want\--a list of every
 appearance for an address.
 
 ### Querying the Index
 
 Given any address, our applications query the index chunks by scanning
-through the bloom filters looking for hits. A bloom filter is a small
+through the Bloom filters looking for hits. A Bloom filter is a small
 and super fast method of determining set membership. If, upon query, the
-bloom filter returns 'yes' (it actually returns 'maybe'), then, and only
+Bloom filter returns 'yes' (it actually returns 'maybe'), then, and only
 then, do we search the much larger chunk.
 
-If the bloom filter *hits* (that is, it indicates that the address may
+If the Bloom filter *hits* (that is, it indicates that the address may
 be present in the chunk), we need to open and search the associated
 chunk.
 
-If the bloom filter *misses*, we may skip the index chunk. (A bloom
+If the Bloom filter *misses*, we may skip the index chunk. (A Bloom
 filter is never wrong when it says a data item does not belong to the
 set.) We estimate, for any given address for a 'typical' user, nearly
-90% of the bloom filters miss. This means that the query skips nearly
+90% of the Bloom filters miss. This means that the query skips nearly
 90% of the index chunks. This speeds up the search significantly.
 
-Note that the bloom filters are small enough, in total, to store in
+Note that the Bloom filters are small enough, in total, to store in
 memory. Additionally, because the index chunks are sorted by address,
 when we are forced to query the chunk, we can complete a very fast
 binary search looking for appearances.
@@ -296,8 +296,8 @@ chifra list 0xf503017d7baf7fbc0fff7492b751025c6a78179b
 ```
 
 If you run this command (and your scraper is caught up to the front of
-the chain), you will see that chifra scans the bloom filters, opening
-the index chunks only if the bloom filter hits.
+the chain), you will see that chifra scans the Bloom filters, opening
+the index chunks only if the Bloom filter hits.
 
 If the address appears in the chunk, chifra caches that appearance
 (again in a fixed-width binary file). The next time we list the
@@ -442,7 +442,7 @@ We've shown that:
 4)  In response to this impossibility, one must chunk the index (that
     > is, create a time-ordered log of indexes of a time-ordered log),
 
-5)  Placing a bloom filter in front of a chunked index wildly speeds up
+5)  Placing a Bloom filter in front of a chunked index wildly speeds up
     > the search of the index,
 
 6)  In order to properly work on an end user's machine, the system must
@@ -476,7 +476,7 @@ server. In Web 3.0 / content-addressable data environment, the more
 users the system gets, the more those users themselves help build and
 manage the infrastructure.
 
-If two people download and pin the TrueBlocks bloom filters on IPFS,
+If two people download and pin the TrueBlocks Bloom filters on IPFS,
 they are twice as likely to be found. This aspect of the system grows
 exponentially. The more users the system acquires, the more likely each
 new user is to find the data she's looking for (assuming all users are
@@ -496,8 +496,8 @@ small burden. Larger users carry a larger burden.
 *[Tiny Footprint]{.ul}*
 
 The footprint of the initial installation of the TrueBlocks system is
-small. Only the bloom filters need to be installed at first. As the user
-scans the bloom filters looking for address appearances, interesting
+small. Only the Bloom filters need to be installed at first. As the user
+scans the Bloom filters looking for address appearances, interesting
 chunks need to be downloaded from IPFS. Once downloaded, the chunk can
 then be searched and pinned on IPFS if the address is found thereby
 making that chunk more likely to be found in the future by other users.
@@ -520,12 +520,12 @@ system.
 In addition to all of the above, the TrueBlocks data is also provably
 true. We prove our data by inserting into the data itself the git commit
 hash of the software instructions (i.e. the code) that builds the index
-chunks and bloom filters. This hash is inserted into the manifest file
+chunks and Bloom filters. This hash is inserted into the manifest file
 that we use to report the location of the data to our software.
 
 The manifest is updated during the creation of each chunk by storing the
-IPFS hashes of the chunk and the associated bloom filter, adding the
-IPFS hash of the file format for both the chunk and the bloom filter and
+IPFS hashes of the chunk and the associated Bloom filter, adding the
+IPFS hash of the file format for both the chunk and the Bloom filter and
 the above mentioned git commit hash into the manifest. Each manifest
 includes a hash to the previous manifest, so the user may walk his/her
 way backwards through the data. We then store the manifest on IPFS as
@@ -534,7 +534,7 @@ smart contract. See the above mentioned UnchainedIndex website for more
 information.
 
 In this way, our end-user applications always know where to go on IPFS
-to get the bloom filters. The app simply queries the Unchained Index
+to get the Bloom filters. The app simply queries the Unchained Index
 smart contract to find the latest hash of the manifest. Upshot - zero
 cost to publish the data. Everyone has access to the data at all times
 if they have access to the Ethereum chain.

--- a/content/blog/explainers/long-winded-explanation.md
+++ b/content/blog/explainers/long-winded-explanation.md
@@ -58,7 +58,7 @@ There are a number of other options (including exporting to csv and tab
 delimited data), but I will focus on just one that directly affects the
 issue of indexing the chain:
 
-`chifra blocks \--uniq_tx 12000000`
+`chifra blocks --uniq_tx 12000000`
 
 exports what we call 'every appearance of every address in the block'.
 'Appearance' here isan important concept. An 'appearance' includes

--- a/content/blog/medium-posts/035-Simple-Undeniable-Facts.md
+++ b/content/blog/medium-posts/035-Simple-Undeniable-Facts.md
@@ -110,14 +110,14 @@ So off we go…
 1. Above, I mentioned an index of `appearances`. This index is needed so users know which blocks to look for.
 2. With TrueBlocks, we’ve already built the software that builds, hashes, pins, and queries the appearance index.
 3. After nearly 10,000,000 blocks, TrueBlocks has produced more than 3,500 snapshots of the appearance index. This index is immutable, compact, stored as a binary file both locally and in IPFS, and takes up about 35GB _on our hard drive_. TrueBlocks search it with 100% privacy.
-4. To lessen the size of the index, we went a step further and produced bloom filters of each snapshot. Just like the snapshots, the bloom filters are immutable, very compact, and pinned on IPFS. The bloom filters allow TrueBlocks to identify which chunks of index are needed. The bloom filters are only 1.5 GB (also in 3,500 files), making them even more accessible to regular users.
-5. We go even further than that. For both the bloom filters and the index chunks, we produce text files listing the hashes which we distribute as part of the software. The first time one runs TrueBlocks, it downloads 1.5 GB of bloom filters. It then starts a daemon to catches up to (and keep up to) the front of the chain.
-6. Using the bloom filters, the software queries (quickly) for a list of snapshots. The list of snapshots are then downloaded. For almost every address, this list is very, very small.
+4. To lessen the size of the index, we went a step further and produced Bloom filters of each snapshot. Just like the snapshots, the Bloom filters are immutable, very compact, and pinned on IPFS. The Bloom filters allow TrueBlocks to identify which chunks of index are needed. The Bloom filters are only 1.5 GB (also in 3,500 files), making them even more accessible to regular users.
+5. We go even further than that. For both the Bloom filters and the index chunks, we produce text files listing the hashes which we distribute as part of the software. The first time one runs TrueBlocks, it downloads 1.5 GB of Bloom filters. It then starts a daemon to catches up to (and keep up to) the front of the chain.
+6. Using the Bloom filters, the software queries (quickly) for a list of snapshots. The list of snapshots are then downloaded. For almost every address, this list is very, very small.
 7. For popular addresses (such as CryptoKitties, ENS, or DAI) the list of snapshots is very large. Nearly every chunk is of interest.
 8. **Conclusion:** This naturally requires heavy users of the chain to download and pin much more data than regular users — this is a very desirable quality for a distributed system. It’s naturally fair.
-9. Once one has the list of hashes, one has undeniable, fully-local, 100% private access to the bloom filters.
+9. Once one has the list of hashes, one has undeniable, fully-local, 100% private access to the Bloom filters.
 10. This gives one undeniable access to the minimal list of index chunks. This give undeniable and fully-local access to every transaction for an address.
-11. The list of bloom filter hashes is [here](https://github.com/TrueBlocks/trueblocks-core/blob/master/src/other/install/ipfs-hashes/blooms.txt).
+11. The list of Bloom filter hashes is [here](https://github.com/TrueBlocks/trueblocks-core/blob/master/src/other/install/ipfs-hashes/blooms.txt).
 12. The list of IPFS hashes of the chunked appearance index is [here](https://github.com/TrueBlocks/trueblocks-core/blob/master/src/other/install/ipfs-hashes/finalized.txt).
 13. **Conclusion:** The above two links and [the TrueBlocks software](https://github.com/TrueBlocks/trueblocks-core) gives everyone access to a full index of appearances of every addresses anywhere on the chain. This access comes _on your own local machine. From_ there, you can operate 100% privately and fully decentrally.
 

--- a/content/blog/medium-posts/038-How-Accurate-is-EtherScan.md
+++ b/content/blog/medium-posts/038-How-Accurate-is-EtherScan.md
@@ -21,7 +21,7 @@ How is this possible? Isn’t Ethereum supposed to be an 18-decimal-place accura
 
 The answer, of course, is that Ethereum always does balance.
 
-Why then is Mr. Green having trouble? It’s because he’s not using the Etheruem data directly. He’s using OPD (other people’s data). Very few of us are using data straight from the chain. We almost all of us get our Ethereum data from an API or a website. In the Ethereum ecosystem, this means either Infura or EtherScan.
+Why then is Mr. Green having trouble? It’s because he’s not using the Ethereum data directly. He’s using OPD (other people’s data). Very few of us are using data straight from the chain. We almost all of us get our Ethereum data from an API or a website. In the Ethereum ecosystem, this means either Infura or EtherScan.
 
 I, like Mr. Green, want those annoying little digits to behave themselves. I’m becoming increasingly concerned, especially as smart contracts become more and more complicated, about the fact that “Nothing ever balances.”
 

--- a/content/blog/medium-posts/044-Dynamic-Traversers-for-TrueBlocks.md
+++ b/content/blog/medium-posts/044-Dynamic-Traversers-for-TrueBlocks.md
@@ -59,7 +59,7 @@ Once you finished installing (if you have trouble, join our discord server), try
 chifra init
 ```
 
-This will initialize the TrueBlocks indexes and downloads the most recent collection of bloom filters. Next, run
+This will initialize the TrueBlocks indexes and downloads the most recent collection of Bloom filters. Next, run
 a small test to see if things are working properly
 
 ```[shell]

--- a/content/docs/chifra/admin.md
+++ b/content/docs/chifra/admin.md
@@ -101,9 +101,9 @@ The scraper can scrape either the index only, previously created monitors only, 
 
 Each time `chifra scrape` runs, it begins at the last block it completed (plus one) and decends as deeply as it can into the block's data. (This is why we need a `--tracing` node.) As address appearances are encountered, the system adds the appearance to a binary index. Periodically (at the end of the block containing the 2,000,000th appearance), the system consolidates a **chunk**.
 
-A **chunk** is a portion of the index containing approximately 2,000,000 records. As part of the consolidation, the scraper creates a bloom filter representing the chunk. The bloom filters are an order of magnitude or more smaller than the chunks. The system then pushes both the chunk and the bloom filter to IPFS. In this way, TrueBlocks creates an immutable, uncapturable index of appearances that can be used not only by TrueBlocks, but any member of the community who needs it. (Hint: we all need it.)
+A **chunk** is a portion of the index containing approximately 2,000,000 records. As part of the consolidation, the scraper creates a Bloom filter representing the chunk. The Bloom filters are an order of magnitude or more smaller than the chunks. The system then pushes both the chunk and the Bloom filter to IPFS. In this way, TrueBlocks creates an immutable, uncapturable index of appearances that can be used not only by TrueBlocks, but any member of the community who needs it. (Hint: we all need it.)
 
-Users of the [TrueBlocks Explorer](https://github.com/TrueBlocks/trueblocks-explorer) (or any other software, for that matter) subsequently downloads the bloom filters, queries them to determine which **chunks** need to be downloaded to the user's machine and thereby build a historical list of transacitons for a given address. This is accomplished while imposing a minimum amount of data on the end user's machine.
+Users of the [TrueBlocks Explorer](https://github.com/TrueBlocks/trueblocks-explorer) (or any other software, for that matter) subsequently downloads the Bloom filters, queries them to determine which **chunks** need to be downloaded to the user's machine and thereby build a historical list of transacitons for a given address. This is accomplished while imposing a minimum amount of data on the end user's machine.
 
 In future versions of the software, we will pin these shared chunks and blooms on end user's machines. They need the data for the software to operate and sharing it makes all user's better off. A naturally-born network effect.
 
@@ -118,7 +118,7 @@ Please see [this article](.) for more information about running the scraper and 
 
 ## chifra init
 
-When invoked, `chifra init` looks at a smart contract called **The Unchained Index** ([0xcfd7f3b24f3551741f922fd8c4381aa4e00fc8fd](https://etherscan.io/address/0xcfd7f3b24f3551741f922fd8c4381aa4e00fc8fd)). From this smart contract, it extracts a data item called `manifestHash`. The `manifestHash` is an IPFS hash that points to a file (a manifest) that contains every previously pinned bloom filter and index chunk. TrueBlocks periodically publishes the manifest's hash to the smart contract. This makes the entire index both available for our software to use and impossible for us to withhold. Both of these aspects of the manifest are included by design.
+When invoked, `chifra init` looks at a smart contract called **The Unchained Index** ([0xcfd7f3b24f3551741f922fd8c4381aa4e00fc8fd](https://etherscan.io/address/0xcfd7f3b24f3551741f922fd8c4381aa4e00fc8fd)). From this smart contract, it extracts a data item called `manifestHash`. The `manifestHash` is an IPFS hash that points to a file (a manifest) that contains every previously pinned Bloom filter and index chunk. TrueBlocks periodically publishes the manifest's hash to the smart contract. This makes the entire index both available for our software to use and impossible for us to withhold. Both of these aspects of the manifest are included by design.
 
 If you stop `chifra init` before it finishes, it will pick up against where it left off the next time you run it.
 
@@ -129,14 +129,14 @@ If you run `chifra init` and allow it to complete, the next time you run `chifra
 ### usage
 
 `Usage:`    chifra init
-`Purpose:`  Leech the bloom filters from IPFS by first downloading the pin manifest from a smart contract and then downloading the blooms. Optionally `--pin` the resulting download in order to share it with others.
+`Purpose:`  Leech the Bloom filters from IPFS by first downloading the pin manifest from a smart contract and then downloading the blooms. Optionally `--pin` the resulting download in order to share it with others.
 
 `Where:`
 
 | | Option | Description |
 | :----- | :----- | :---------- |
-| -i | --init | initialize local index by downloading bloom filters from pinning service |
-| -k | --init_all | initialize local index by downloading both bloom filters and index chunks |
+| -i | --init | initialize local index by downloading Bloom filters from pinning service |
+| -k | --init_all | initialize local index by downloading both Bloom filters and index chunks |
 | -p | --pin_locally | pin all local files in the index to an IPFS store (requires IPFS) |
 | -v | --verbose | set verbose level (optional level defaults to 1) |
 | -h | --help | display this help screen |
@@ -153,15 +153,15 @@ This tool is not yet ready for production use. Please return to this page later.
 ### usage
 
 `Usage:`    chifra pins [-l|-i|-k|-p|-v|-h]
-`Purpose:`  Manage pinned index of appearances and associated bloom filters.
+`Purpose:`  Manage pinned index of appearances and associated Bloom filters.
 
 `Where:`
 
 | | Option | Description |
 | :----- | :----- | :---------- |
-| -l | --list | list the index and bloom filter hashes from local manifest or pinning service |
-| -i | --init | initialize local index by downloading bloom filters from pinning service |
-| -k | --init_all | initialize local index by downloading both bloom filters and index chunks |
+| -l | --list | list the index and Bloom filter hashes from local manifest or pinning service |
+| -i | --init | initialize local index by downloading Bloom filters from pinning service |
+| -k | --init_all | initialize local index by downloading both Bloom filters and index chunks |
 | -p | --pin_locally | pin all local files in the index to an IPFS store (requires IPFS) |
 | -v | --verbose | set verbose level (optional level defaults to 1) |
 | -h | --help | display this help screen |

--- a/content/docs/prologue/do-i-need-a-node.md
+++ b/content/docs/prologue/do-i-need-a-node.md
@@ -25,7 +25,7 @@ your machine. But you have to make a compromise somewhere else.
 
 If you can't run a node, TrueBlocks offers two solution. You can either:
 
-* Build the index locally, but make quieries to a remote RPC.
+* Build the index locally, but make queries to a remote RPC.
 * Build the index from our IPFS manifest, but lose access to live data
 
 ### Lose ownership: query using a remote RPC

--- a/content/docs/prologue/do-i-need-a-node.md
+++ b/content/docs/prologue/do-i-need-a-node.md
@@ -48,7 +48,7 @@ privacy and performance benefits.
 * The index is immutable, so you know whether it's been tampered with
 * The index is decentralized, so no one owns it
 * The query directly from your machine, so  it's lightning fast
-* We use bloom filters, so you need to store only the fraction of the blockchain that you are interested in 
+* We use Bloom filters, so you need to store only the fraction of the blockchain that you are interested in 
 
 Of course, the problem is that we only publish to the IPFS periodically.
 This means our version doesn't contain the latest data.

--- a/content/docs/prologue/indexing-addresses.md
+++ b/content/docs/prologue/indexing-addresses.md
@@ -27,7 +27,7 @@ If you have access to an Ethereum tracing node such as TurboGeth, you can build 
 For this page, we take advantage of the fact that TrueBlocks, LLC (the company) produces the index and publishes it to IPFS. We do this for our own reasons─our software doesn't work without it.
 We purposefully publish the index data to IPFS so that once our users have it, we can not take it back. This makes it impossible for us to hold our users hostage.
 
-Each time we publish an index chunk (and its associated bloom filter) to IPFS, we add a record to a *manifest*. The manifest lists all of the index chunks and bloom filters.
+Each time we publish an index chunk (and its associated Bloom filter) to IPFS, we add a record to a *manifest*. The manifest lists all of the index chunks and Bloom filters.
 
 So we can't take it back, we publish the manifest to IPFS. This IPFS hash to the manifest gives us a list of all the IPFS hashes of the entire address index.
 In other words, we've published immutable, irrevocable access to the entire index for anyone who has the hash of the manifest to use─not only now but into the far foggy future.
@@ -130,6 +130,6 @@ curl -s "http://gateway.ipfs.io/ipfs/QmSJeyXsvNpyXprdfwL5JyiS39VLU7m1kQNun4uM5XQ
 
 ## Getting all the Blooms
 
-Additionally, we publish the IPFS hash of a manifest file to smart contract we call the *Unchained Index.* The mainfest file details all the hashes of all the chunks of the index along with all the bloom filters.
+Additionally, we publish the IPFS hash of a manifest file to smart contract we call the *Unchained Index.* The mainfest file details all the hashes of all the chunks of the index along with all the Bloom filters.
 
 [ UNDER CONSTRUCTION -- PLEASE RETURN LATER ]

--- a/content/docs/prologue/introduction.md
+++ b/content/docs/prologue/introduction.md
@@ -22,9 +22,9 @@ toc: true
 
 4. To solve this problem, the Ethereum node needs to index the blockchain. TrueBlocks builds this missing index. However, we don't want to build it and be able to later control it or limit access to it. That's where IPFS comes in. We build a chunked index (that is, periodically we stop adding data to the growing chunk). This allows us to store the chunk immutably on IPFS.
 
-5. Before storing the data, we add a bloom filter that covers the index chunk. We publish this immutable bloom filter to IPFS as well. The bloom filter is very small and speeds up the search of the chunked index by orders of magnitude.
+5. Before storing the data, we add a Bloom filter that covers the index chunk. We publish this immutable Bloom filter to IPFS as well. The Bloom filter is very small and speeds up the search of the chunked index by orders of magnitude.
 
-6. Because end-user machines have small hard drives and we wish to permissionlessly and irrevocably distribute the index, TrueBlocks only downloads the much smaller bloom filters to the end users machine on first install. Subsequent queries for an address first check the bloom filter and only download the associated full index chunk of there's a hit on the bloom filter. In this way, each user downloads only the portion of the index that is of interest to them.
+6. Because end-user machines have small hard drives and we wish to permissionlessly and irrevocably distribute the index, TrueBlocks only downloads the much smaller Bloom filters to the end users machine on first install. Subsequent queries for an address first check the Bloom filter and only download the associated full index chunk of there's a hit on the Bloom filter. In this way, each user downloads only the portion of the index that is of interest to them.
 
 7. Those who say it is impossible to index the Ethereum blockchain on small, desktop machines are wrong.
 

--- a/content/docs/prologue/what-is-this.md
+++ b/content/docs/prologue/what-is-this.md
@@ -49,7 +49,7 @@ want to make─addresses, names, ABIs, etc.
 
 In addition to the command line, TrueBlocks also provides a graphical user interface
 with the [Explorer](/docs/explorer/gui-for-trueblocks) application.
-So you don't need any to be highly technical to use TrueBlocks.
+So you don't need to be highly technical to use TrueBlocks.
 
 ### And yes, it's permissionless
 
@@ -67,10 +67,10 @@ Some highlights:
 
 - Querying straight from your hard drive is _faster by many factors._
 - Binary cache makes subsequent queries _nearly instantaneous_
-- Leaving the data on the chain until it's queried shrinks storage requirements for the typical user from _terrabytes to gigabytes_.
+- Leaving the data on the chain until it's queried shrinks storage requirements for the typical user from _terabytes to gigabytes_.
 - Bloom filters further reduce computation and storage overhead
 - Articulate to resolve transactions on the byte level, _turning byte streams into human-readable data._
-- _Format agnostic._ Receive data in JSON, CSV, plain text, etc.
+- _Format-agnostic._ Receive data in JSON, CSV, plain text, etc.
 
 TrueBlocks performs so well because the design is 100% data first. We are lifelong
 hackers, and we agree with Linus:

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -32,7 +32,7 @@
     <div class="row justify-content-center text-center">
       <div class="col-lg-5">
         <h2 class="h4">Lightweight</h2>
-        <p>Using bloom filters massively reduces storage needs </p>
+        <p>Using Bloom filters massively reduces storage needs </p>
       </div>
       <div class="col-lg-5">
         <h2 class="h4">Query only the data you want</h2>


### PR DESCRIPTION
A couple typos I found while going through the docs' intro.

Most of the diff is just to capitalize "Bloom filter" consistently, but other changes are in separate commits to make it easier to review.

Note that the "Ethereum" misspell is also on https://unchainedindex.io/ (which is why I found it in a random Medium post), but I couldn't find the source code for that site.