### PR TITLE
Remove facebook meta tags

### DIFF
--- a/layouts/partials/head/opengraph.html
+++ b/layouts/partials/head/opengraph.html
@@ -73,12 +73,6 @@
 
 {{ if .IsPage -}}
   {{ range .Site.Authors -}}
-    {{ with .Social.facebook -}}
-      <meta property="article:author" content="https://www.facebook.com/{{ . }}">
-    {{ end -}}
-    {{ with .Site.Social.facebook -}}
-      <meta property="article:publisher" content="https://www.facebook.com/{{ . }}">
-    {{ end -}}
     <meta property="article:section" content="{{ .Section }}">
     {{ with .Params.tags -}}
       {{ range first 6 . -}}

--- a/layouts/partials/head/seo.html
+++ b/layouts/partials/head/seo.html
@@ -39,8 +39,6 @@
 <meta name="twitter:creator" content="@{{ .Site.Params.twitterCreator }}">
 
 {{ partial "head/opengraph.html" . }}
-<meta property="article:publisher" content="https://www.facebook.com/{{ .Site.Params.facebookPublisher }}">
-<meta property="article:author" content="https://www.facebook.com/{{ .Site.Params.facebookAuthor }}">
 <meta property="og:locale" content="{{ .Site.Params.ogLocale }}">
 
 {{ range .AlternativeOutputFormats -}}


### PR DESCRIPTION
When sharing in Telegram, the link rendered "www.facebook.com" as below. Apparently this is because of the "article:author" and "article:publisher" tags. Remove the tags 

<img width="440" alt="image" src="https://user-images.githubusercontent.com/13069972/194943443-80ac1e87-db4a-4108-b7d7-f3d139391b81.png">
