### PR TITLE
Only run deploy job when main branch is pushed

### DIFF
--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -2,8 +2,6 @@ name: hugo rsync
 on:
   push:
     branches: [ main ]
-  pull_request:
-    branches: [ main, develop ]
   workflow_dispatch:
     branches: [ main, develop ]
 jobs:


### PR DESCRIPTION
This changes action configuration so that deployment job is only ran when there's a push to `main` branch